### PR TITLE
Allow all remote image hosts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -48,6 +48,18 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: 'https',
+        hostname: 'www.homecontrols.com',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'homecontrols.com',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
         hostname: '*.amazonaws.com',
         port: '',
         pathname: '/**',
@@ -55,6 +67,19 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: '*.cloudfront.net',
+        port: '',
+        pathname: '/**',
+      },
+      // Allow images from any remote host (supports both HTTPS and HTTP)
+      {
+        protocol: 'https',
+        hostname: '**',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'http',
+        hostname: '**',
         port: '',
         pathname: '/**',
       },


### PR DESCRIPTION
## Summary
- allow Next.js image optimization to load assets from any remote host (http and https)

## Testing
- `npm run typecheck` *(fails: existing TypeScript errors unrelated to this change)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944c97490448322b4c1ff99f2a18a40)