### PR TITLE
Add manual winner selection for prizes

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -64,6 +64,7 @@ export type AuctionAction =
   | { type: 'ALLOCATE_TICKETS'; payload: { prizeId: string; userId: string; userName: string; count: number } }
   | { type: 'DRAW_WINNERS' }
   | { type: 'DRAW_SINGLE_WINNER'; payload: { prizeId: string } }
+  | { type: 'ASSIGN_SPECIFIC_WINNER'; payload: { prizeId: string; userId: string } }
   | { type: 'DRAW_TIER_WINNERS'; payload: { tierId: string } }
   | { type: 'RESET_AUCTION' }
   | { type: 'REDRAW_PRIZE_WINNER'; payload: { prizeId: string } }


### PR DESCRIPTION
## Summary
- add admin controls to manually assign a specific winner to a prize
- validate eligible entrants, respect winner capacity, and trigger conflict handling when needed
- surface manual assignments in the slot machine display while persisting to Firebase winners

## Testing
- npm run lint *(fails: prompts to configure ESLint interactively; no config applied)*
- npm run typecheck *(fails: existing TypeScript errors in admin and winners pages as well as winner conflict resolution logic)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944cbb5e47c8322ac21dfcfdaad9d3e)