### PR TITLE
perf: Replace JSON.stringify with efficient shallow comparison for wi…

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1055,10 +1055,40 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
           });
           
           // Only dispatch if the winners data has actually changed
-          const currentWinnersString = JSON.stringify(state.winners);
-          const newWinnersString = JSON.stringify(winnersData);
-          
-          if (currentWinnersString !== newWinnersString) {
+          const isWinnersDataEqual = (
+            current: Record<string, string[]>,
+            updated: Record<string, string[]>
+          ): boolean => {
+            const currentKeys = Object.keys(current);
+            const updatedKeys = Object.keys(updated);
+
+            if (currentKeys.length !== updatedKeys.length) {
+              return false;
+            }
+
+            for (const key of currentKeys) {
+              if (!updated.hasOwnProperty(key)) {
+                return false;
+              }
+
+              const currentArray = current[key];
+              const updatedArray = updated[key];
+
+              if (currentArray.length !== updatedArray.length) {
+                return false;
+              }
+
+              for (let i = 0; i < currentArray.length; i++) {
+                if (currentArray[i] !== updatedArray[i]) {
+                  return false;
+                }
+              }
+            }
+
+            return true;
+          };
+
+          if (!isWinnersDataEqual(state.winners, winnersData)) {
             console.log('Winners updated from Firebase:', winnersData);
             dispatch({
               type: 'SYNC_WINNERS_FROM_FIREBASE',


### PR DESCRIPTION
…nners data

Replace inefficient JSON.stringify() deep equality check with optimized shallow comparison function in Firebase winners listener. This eliminates serialization overhead during real-time winner synchronization, improving performance during active drawing sessions when multiple users are connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)