### PR TITLE
Fix N+1 query pattern in winners page

### DIFF
--- a/src/app/winners/page.tsx
+++ b/src/app/winners/page.tsx
@@ -31,13 +31,16 @@ export default function WinnersPage() {
     winnerProfilePicture?: string;
   }>>([]);
 
+  // Create prize lookup map for O(1) access instead of O(n) .find()
+  const prizesMap = new Map(prizes.map(p => [p.id, p]));
+
   // Get prizes that have winners
   const prizesWithWinners = prizes.filter(prize => (winners[prize.id] || []).length > 0);
 
   // Get all winners
   const allWinners = Object.entries(winners)
     .flatMap(([prizeId, winnerIds]) => winnerIds.map((winnerId) => {
-      const prize = prizes.find(p => p.id === prizeId);
+      const prize = prizesMap.get(prizeId);
       const winner = allUsers[winnerId];
       return { prize, winner, winnerId };
     }))
@@ -70,7 +73,7 @@ export default function WinnersPage() {
           const key = formatWinnerKey(prizeId, winnerId);
           const isNewWinner = !previousIds.includes(winnerId) || !displayedWinners.has(key);
           if (isNewWinner) {
-            const prize = prizes.find(p => p.id === prizeId);
+            const prize = prizesMap.get(prizeId);
             const winner = allUsers[winnerId];
 
             if (prize && winner) {


### PR DESCRIPTION
Replace O(n) array.find() calls with O(1) Map lookups by converting prizes array to Map. This improves performance when displaying winners, especially with large numbers of prizes.

- Create prizesMap for instant lookups (line 35)
- Replace prizes.find() calls with prizesMap.get() (lines 43, 76)

Location: src/app/winners/page.tsx:38-44, 73