### PR TITLE
fix: Force fresh Vercel build to resolve env var caching issue

### DIFF
--- a/.vercel-build-id
+++ b/.vercel-build-id
@@ -1,0 +1,1 @@
+2025-12-22-force-rebuild-env-vars

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,10 @@ import type {NextConfig} from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */
+  // Force fresh build - updated 2025-12-22 to fix env var caching issue
+  generateBuildId: async () => {
+    return `build-${Date.now()}`;
+  },
   typescript: {
     ignoreBuildErrors: true,
   },


### PR DESCRIPTION
The app was serving different JavaScript bundles built at different times:
- /env-check page had env vars baked in (built recently)
- Main app pages had undefined env vars (built from cache)

This commit forces a completely fresh build:
1. Added generateBuildId to create unique build ID on each deploy
2. Added .vercel-build-id cache-busting file
3. This ensures all routes get the same env var values

After this deploys, all pages will have NEXT_PUBLIC_FIREBASE_* env vars properly baked in.

Issue: Split build cache caused inconsistent env var injection across routes
Fix: Force fresh build on every deployment to ensure consistency