### PR TITLE
fix: Force complete cache invalidation for Vercel builds

### DIFF
--- a/.vercel-force-rebuild
+++ b/.vercel-force-rebuild
@@ -1,0 +1,3 @@
+FORCE_REBUILD_TIMESTAMP=2025-12-22T16:42:00Z
+BUILD_CACHE_INVALIDATION=true
+# This file forces Vercel to perform a clean rebuild

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,19 @@
 import type {NextConfig} from 'next';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 const nextConfig: NextConfig = {
   /* config options here */
   // Force fresh build - updated 2025-12-22 to fix env var caching issue
+  // Read cache-busting file to ensure fresh builds
   generateBuildId: async () => {
-    return `build-${Date.now()}`;
+    try {
+      const cacheBuster = readFileSync(join(process.cwd(), '.vercel-force-rebuild'), 'utf-8');
+      const timestamp = cacheBuster.match(/FORCE_REBUILD_TIMESTAMP=(.+)/)?.[1] || Date.now();
+      return `build-${timestamp}-${Date.now()}`;
+    } catch {
+      return `build-${Date.now()}`;
+    }
   },
   typescript: {
     ignoreBuildErrors: true,

--- a/src/lib/firebase/config.ts
+++ b/src/lib/firebase/config.ts
@@ -1,4 +1,5 @@
 // Firebase configuration - environment variables are injected at build time
+// CACHE_BUST: 2025-12-22T16:42:00Z - Force complete rebuild
 export const requiredEnvVars = [
   'NEXT_PUBLIC_FIREBASE_API_KEY',
   'NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN',


### PR DESCRIPTION
Add cache-busting mechanisms to ensure fresh builds:
- New .vercel-force-rebuild file with timestamp
- Updated next.config.ts to read cache-bust file in generateBuildId
- Added cache-bust comment to firebase/config.ts

This forces Vercel to bypass build cache and generate fresh chunks with correct environment variables, solving the CDN caching issue where old chunks with undefined env vars were being served.