### PR TITLE
fix: resolve winners dashboard update bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "tsx": "^4.19.2",
-        "typescript": "^5"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -9781,9 +9781,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "tsx": "^4.19.2",
-    "typescript": "^5"
+    "typescript": "5.9.3"
   }
 }

--- a/src/app/winners/page.tsx
+++ b/src/app/winners/page.tsx
@@ -73,7 +73,7 @@ export default function WinnersPage() {
 
     // Find newly drawn winners (only after initial load)
     if (!isInitialLoad) {
-      const newWinners = [];
+      const newWinners: Array<{ prizeId: string; winnerId: string; winnerName: string; prizeName: string; winnerProfilePicture?: string }> = [];
       for (const [prizeId, winnerIds] of Object.entries(currentWinners)) {
         const previousIds = previousWinners[prizeId] || [];
         winnerIds.forEach((winnerId) => {

--- a/src/app/winners/page.tsx
+++ b/src/app/winners/page.tsx
@@ -21,6 +21,7 @@ export default function WinnersPage() {
     winnerProfilePicture?: string;
   } | null>(null);
   const [displayedWinners, setDisplayedWinners] = useState<Set<string>>(new Set());
+  const displayedWinnersRef = useRef<Set<string>>(displayedWinners);
   const previousWinnersRef = useRef<Record<string, string[]>>({});
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const [winnerQueue, setWinnerQueue] = useState<Array<{
@@ -46,6 +47,11 @@ export default function WinnersPage() {
     }))
     .filter(item => item.prize && item.winner);
 
+  // Keep displayedWinnersRef in sync
+  useEffect(() => {
+    displayedWinnersRef.current = displayedWinners;
+  }, [displayedWinners]);
+
   // Watch for new winners and show slot machine
   useEffect(() => {
     const currentWinners = { ...winners };
@@ -59,6 +65,7 @@ export default function WinnersPage() {
       });
 
       setDisplayedWinners(initialKeys);
+      displayedWinnersRef.current = initialKeys;
       previousWinnersRef.current = currentWinners;
       setIsInitialLoad(false);
       return;
@@ -71,7 +78,7 @@ export default function WinnersPage() {
         const previousIds = previousWinners[prizeId] || [];
         winnerIds.forEach((winnerId) => {
           const key = formatWinnerKey(prizeId, winnerId);
-          const isNewWinner = !previousIds.includes(winnerId) || !displayedWinners.has(key);
+          const isNewWinner = !previousIds.includes(winnerId) || !displayedWinnersRef.current.has(key);
           if (isNewWinner) {
             const prize = prizesMap.get(prizeId);
             const winner = allUsers[winnerId];
@@ -96,7 +103,7 @@ export default function WinnersPage() {
     }
 
     previousWinnersRef.current = currentWinners;
-  }, [winners, prizes, allUsers, displayedWinners, isInitialLoad]);
+  }, [winners, prizes, allUsers, isInitialLoad]);
 
   // Process winner queue - show slot machines sequentially
   useEffect(() => {
@@ -229,7 +236,7 @@ export default function WinnersPage() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
         {allWinners.map(({ prize, winner, winnerId }) => (
-          <Card key={prize!.id} className="overflow-hidden shadow-lg hover:shadow-xl transition-shadow duration-300 border-accent/20">
+          <Card key={`${prize!.id}-${winnerId}`} className="overflow-hidden shadow-lg hover:shadow-xl transition-shadow duration-300 border-accent/20">
             <CardHeader className="p-0 relative">
               <Image
                 src={prize!.imageUrl || 'https://placehold.co/300x200.png'}

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 import type { Dispatch, ReactNode } from 'react';
-import React, { createContext, useContext, useReducer, useMemo, useEffect } from 'react';
+import React, { createContext, useContext, useReducer, useMemo, useEffect, useRef } from 'react';
 import type { Prize, AppUser, AuctionContextState, AuctionAction, PrizeTier } from '@/lib/types';
 import { toast } from '@/hooks/use-toast';
 import { PARTY_CHECKIN_FLAG_KEY } from '@/lib/partyCheckIn';
@@ -796,6 +796,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   const [state, dispatch] = useReducer(auctionReducer, loadPersistedState());
   const [isHydrated, setIsHydrated] = React.useState(false);
   const [allocationsLoaded, setAllocationsLoaded] = React.useState<string | null>(null);
+  const winnersRef = useRef(state.winners);
 
   // Hydrate from localStorage on client side only
   React.useEffect(() => {
@@ -959,9 +960,15 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   }, [state.currentUser, state.prizes, state.winners, state.isAuctionOpen, state.allUsers, state.prizeTiers, state.pendingConflict, state.drawsPaused]);
 
   // Load Firebase data on mount and set up real-time listeners
+  // Keep winnersRef in sync with latest state so the Firebase listener
+  // always compares against the current value (avoids stale closure).
+  useEffect(() => {
+    winnersRef.current = state.winners;
+  }, [state.winners]);
+
   React.useEffect(() => {
     let winnersUnsubscribe: (() => void) | null = null;
-    
+
     const setupFirebaseData = async () => {
       try {
         // Load Firebase prizes and users first
@@ -1082,7 +1089,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
             return true;
           };
 
-          if (!isWinnersDataEqual(state.winners, winnersData)) {
+          if (!isWinnersDataEqual(winnersRef.current, winnersData)) {
             dispatch({
               type: 'SYNC_WINNERS_FROM_FIREBASE',
               payload: winnersData

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -649,7 +649,7 @@ const auctionReducer = (state: AuctionContextState, action: AuctionAction): Auct
       const updatedWinners = { ...state.winners };
 
       // Ensure the kept prize is assigned to the user
-      updatedWinners[keepPrizeId] = userId;
+      updatedWinners[keepPrizeId] = [userId];
 
       // Vacate the dropped prize before redrawing
       delete updatedWinners[dropPrizeId];
@@ -665,7 +665,7 @@ const auctionReducer = (state: AuctionContextState, action: AuctionAction): Auct
         );
 
         if (winnerId && !conflictPrizeId) {
-          updatedWinners[dropPrizeId] = winnerId;
+          updatedWinners[dropPrizeId] = [winnerId];
         } else if (winnerId && conflictPrizeId) {
           nextConflict = {
             id: `conflict-${Date.now()}`,


### PR DESCRIPTION
- Fix stale closure in Firebase onSnapshot listener by using a ref to
  track current winners state, preventing excessive re-renders on every
  Firestore event
- Fix duplicate React keys when prizes have multiple winners by using
  composite key (prizeId-winnerId)
- Fix effect dependency on displayedWinners causing re-evaluation of
  winner queue on every animation completion, using a ref instead

https://claude.ai/code/session_01F5AjJ8KAm8CGuxak11DPHr