### PR TITLE
feat: Add one-click test lottery flow with seed data and bulk allocation

### DIFF
--- a/src/components/WinnerDrawing.tsx
+++ b/src/components/WinnerDrawing.tsx
@@ -189,110 +189,78 @@ export default function WinnerDrawing() {
     }
   };
 
-  const handleRandomlyAllocateTickets = async () => {
-    // First try to load users from Firebase if local state is empty
-    if (Object.keys(state.allUsers).length <= 2) { // Only admin users
-      try {
-        const { getUsers } = await import('@/lib/firebaseService');
-        const firebaseUsers = await getUsers();
-        
-        if (firebaseUsers.length > 0) {
-          dispatch({
-            type: 'UPLOAD_USERS',
-            payload: firebaseUsers.map(user => ({
-              firstName: user.firstName,
-              lastName: user.lastName,
-              employeeId: user.employeeId,
-              facilityName: user.facilityName,
-              tickets: user.tickets,
-              pin: user.pin
-            }))
-          });
-          
-          toast({
-            title: "Users Loaded",
-            description: `Loaded ${firebaseUsers.length} users from Firebase. Try again.`,
-          });
-          return;
-        }
-      } catch (error) {
-        console.error('Error loading Firebase users:', error);
-        toast({
-          title: "Error",
-          description: "Failed to load users from Firebase.",
-          variant: "destructive"
-        });
-        return;
-      }
-    }
+  const [testLoading, setTestLoading] = useState<string | null>(null);
 
-    // Get all non-admin users
-    const nonAdminUsers = Object.entries(state.allUsers).filter(([userId, user]) => {
-      // Exclude admin users (assuming admin users have 'ADMIN' in their ID or name)
-      return !userId.includes('ADMIN') && !user.name?.includes('ADMIN');
-    });
-
-    if (nonAdminUsers.length === 0) {
+  const handleSeedTestData = async () => {
+    setTestLoading('seed');
+    try {
+      const { seedTestData } = await import('@/lib/firebaseService');
+      const result = await seedTestData();
+      const parts = [];
+      if (result.tiersCreated) parts.push(`${result.tiersCreated} tiers`);
+      if (result.usersCreated) parts.push(`${result.usersCreated} users`);
+      if (result.prizesCreated) parts.push(`${result.prizesCreated} prizes`);
       toast({
-        title: "No Users Found",
-        description: "No non-admin users found to allocate tickets. Try loading users first.",
-        variant: "destructive"
+        title: "Test Data Seeded",
+        description: parts.length > 0 ? `Created ${parts.join(', ')}.` : 'Test data already exists.',
       });
-      return;
+    } catch (error) {
+      console.error('Error seeding test data:', error);
+      toast({ title: "Error", description: "Failed to seed test data.", variant: "destructive" });
+    } finally {
+      setTestLoading(null);
     }
+  };
 
-    if (prizes.length === 0) {
+  const handleBulkAllocate = async () => {
+    setTestLoading('allocate');
+    try {
+      const { bulkAllocateTicketsForTest } = await import('@/lib/firebaseService');
+      const result = await bulkAllocateTicketsForTest();
       toast({
-        title: "No Prizes Found", 
-        description: "No prizes available for ticket allocation.",
-        variant: "destructive"
+        title: "Tickets Allocated",
+        description: result.allocationsCreated > 0
+          ? `Created ${result.allocationsCreated} allocations across all prizes.`
+          : 'No users or prizes found. Seed test data first.',
       });
-      return;
+    } catch (error) {
+      console.error('Error bulk allocating:', error);
+      toast({ title: "Error", description: "Failed to allocate tickets.", variant: "destructive" });
+    } finally {
+      setTestLoading(null);
     }
+  };
 
-    // For each user, randomly distribute their tickets across prizes
-    nonAdminUsers.forEach(([userId, user]) => {
-      const totalTickets = user.tickets || 10; // Default to 10 if not specified
-      let remainingTickets = totalTickets;
-      
-      // Randomly select how many prizes this user will enter
-      const maxPrizes = Math.min(prizes.length, Math.ceil(Math.random() * 3) + 1); // 1-4 prizes max
-      const selectedPrizes = prizes
-        .sort(() => Math.random() - 0.5) // Shuffle
-        .slice(0, maxPrizes);
-
-      selectedPrizes.forEach((prize, index) => {
-        if (remainingTickets <= 0) return;
-        
-        // For the last prize, use all remaining tickets
-        // For others, use 1-50% of remaining tickets
-        let ticketsForThisPrize;
-        if (index === selectedPrizes.length - 1) {
-          ticketsForThisPrize = remainingTickets;
-        } else {
-          const maxForThis = Math.floor(remainingTickets * 0.5);
-          ticketsForThisPrize = Math.max(1, Math.floor(Math.random() * maxForThis) + 1);
-        }
-        
-        // Allocate tickets to this prize
-        dispatch({
-          type: 'ALLOCATE_TICKETS',
-          payload: {
-            prizeId: prize.id,
-            userId: userId,
-            userName: user.name || 'Unknown',
-            count: ticketsForThisPrize
-          }
-        });
-        
-        remainingTickets -= ticketsForThisPrize;
+  const handleFullTestSetup = async () => {
+    setTestLoading('full');
+    try {
+      const { seedTestData, bulkAllocateTicketsForTest } = await import('@/lib/firebaseService');
+      const seedResult = await seedTestData();
+      const allocResult = await bulkAllocateTicketsForTest();
+      toast({
+        title: "Full Test Setup Complete",
+        description: `Seeded ${seedResult.usersCreated} users, ${seedResult.prizesCreated} prizes, ${seedResult.tiersCreated} tiers. Created ${allocResult.allocationsCreated} allocations.`,
       });
-    });
+    } catch (error) {
+      console.error('Error in full test setup:', error);
+      toast({ title: "Error", description: "Failed to complete test setup.", variant: "destructive" });
+    } finally {
+      setTestLoading(null);
+    }
+  };
 
-    toast({
-      title: "Tickets Allocated!",
-      description: `Randomly allocated tickets for ${nonAdminUsers.length} users across ${prizes.length} prizes.`
-    });
+  const handleClearTestData = async () => {
+    setTestLoading('clear');
+    try {
+      const { clearTestData } = await import('@/lib/firebaseService');
+      await clearTestData();
+      toast({ title: "Test Data Cleared", description: "All test users, prizes, and allocations removed." });
+    } catch (error) {
+      console.error('Error clearing test data:', error);
+      toast({ title: "Error", description: "Failed to clear test data.", variant: "destructive" });
+    } finally {
+      setTestLoading(null);
+    }
   };
 
   // Watch for winner updates and update slot machine display
@@ -612,23 +580,65 @@ export default function WinnerDrawing() {
               </div>
             </div>
           </div>
-          {/* Random Ticket Allocation (Testing) */}
+          {/* Testing Helpers */}
           <div className="space-y-3">
             <h3 className="text-lg font-semibold flex items-center gap-2">
               <Zap className="h-4 w-4" />
               Testing Helper
             </h3>
             <p className="text-sm text-muted-foreground">
-              Randomly allocate tickets from all non-admin users across all prizes for testing.
+              Seed test data and randomly allocate tickets to test the full lottery flow end-to-end.
             </p>
-            <Button 
-              onClick={handleRandomlyAllocateTickets}
-              variant="outline"
-              className="w-full"
-            >
-              <Zap className="h-4 w-4 mr-2" />
-              Randomly Allocate All Tickets
-            </Button>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              <Button
+                onClick={handleSeedTestData}
+                variant="outline"
+                disabled={testLoading !== null}
+              >
+                <Users className="h-4 w-4 mr-2" />
+                {testLoading === 'seed' ? 'Seeding...' : 'Seed Test Data'}
+              </Button>
+              <Button
+                onClick={handleBulkAllocate}
+                variant="outline"
+                disabled={testLoading !== null}
+              >
+                <Shuffle className="h-4 w-4 mr-2" />
+                {testLoading === 'allocate' ? 'Allocating...' : 'Allocate Tickets'}
+              </Button>
+              <Button
+                onClick={handleFullTestSetup}
+                variant="default"
+                disabled={testLoading !== null}
+              >
+                <Zap className="h-4 w-4 mr-2" />
+                {testLoading === 'full' ? 'Setting up...' : 'Full Test Setup'}
+              </Button>
+            </div>
+            <Dialog>
+              <DialogTrigger asChild>
+                <Button
+                  variant="destructive"
+                  className="w-full"
+                  disabled={testLoading !== null}
+                >
+                  {testLoading === 'clear' ? 'Clearing...' : 'Clear Test Data'}
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Clear Test Data?</DialogTitle>
+                </DialogHeader>
+                <p className="text-sm text-muted-foreground">
+                  This will remove all test users (TEST-*), test prizes, and their associated allocations and winners.
+                </p>
+                <div className="flex gap-2 justify-end">
+                  <Button variant="destructive" onClick={handleClearTestData}>
+                    Confirm Clear
+                  </Button>
+                </div>
+              </DialogContent>
+            </Dialog>
           </div>
         </CardContent>
       </Card>

--- a/src/lib/firebaseService.ts
+++ b/src/lib/firebaseService.ts
@@ -715,3 +715,212 @@ export const debugWinnersAndUsers = async (): Promise<void> => {
     console.error('Error debugging winners and users:', error);
   }
 };
+
+// ==================== Test Data Helpers ====================
+
+const TEST_USER_PREFIX = 'TEST-';
+const TEST_PRIZE_PREFIX = 'Test Prize';
+const ADMIN_IDS = ['ADMIN001', 'DEV007'];
+
+export const seedTestData = async (options?: {
+  userCount?: number;
+  prizeCount?: number;
+}): Promise<{ usersCreated: number; prizesCreated: number; tiersCreated: number }> => {
+  const userCount = options?.userCount ?? 10;
+  const result = { usersCreated: 0, prizesCreated: 0, tiersCreated: 0 };
+
+  // 1. Seed tiers if none exist
+  const existingTiers = await getPrizeTiers();
+  let tierIds: Record<string, string> = {};
+  if (existingTiers.length === 0) {
+    const tiersToCreate = [
+      { name: 'Grand Prize', description: 'Top-tier prizes', color: '#FFD700', order: 1 },
+      { name: 'Premium', description: 'Premium prizes', color: '#C0C0C0', order: 2 },
+      { name: 'Standard', description: 'Standard prizes', color: '#CD7F32', order: 3 },
+    ];
+    for (const tier of tiersToCreate) {
+      const id = await addPrizeTier(tier);
+      tierIds[tier.name] = id;
+      result.tiersCreated++;
+    }
+  } else {
+    existingTiers.forEach(t => { tierIds[t.name] = t.id!; });
+  }
+
+  // 2. Seed test users if none exist
+  const existingUsers = await getUsers();
+  const existingTestUsers = existingUsers.filter(u => u.employeeId.startsWith(TEST_USER_PREFIX));
+  if (existingTestUsers.length === 0) {
+    const testUsers = Array.from({ length: userCount }, (_, i) => ({
+      firstName: 'Test',
+      lastName: `User ${i + 1}`,
+      employeeId: `${TEST_USER_PREFIX}${String(i + 1).padStart(3, '0')}`,
+      facilityName: 'Test Facility',
+      tickets: 10,
+      pin: '1111',
+      status: 'working' as const,
+    }));
+    await addUsers(testUsers);
+    result.usersCreated = testUsers.length;
+  }
+
+  // 3. Seed test prizes if none exist
+  const existingPrizes = await getPrizes();
+  const existingTestPrizes = existingPrizes.filter(p => p.name.startsWith(TEST_PRIZE_PREFIX));
+  if (existingTestPrizes.length === 0) {
+    const tierNames = Object.keys(tierIds);
+    const grandTierId = tierIds['Grand Prize'] || tierNames[0] && tierIds[tierNames[0]];
+    const premiumTierId = tierIds['Premium'] || tierNames[1] && tierIds[tierNames[1]];
+    const standardTierId = tierIds['Standard'] || tierNames[2] && tierIds[tierNames[2]];
+
+    const prizesToCreate = [
+      { name: 'Test Prize 1 - Grand', description: 'A grand test prize', imageUrl: '', entries: [], totalTicketsInPrize: 0, tierId: grandTierId, numberOfWinners: 1 },
+      { name: 'Test Prize 2 - Premium A', description: 'A premium test prize', imageUrl: '', entries: [], totalTicketsInPrize: 0, tierId: premiumTierId, numberOfWinners: 1 },
+      { name: 'Test Prize 3 - Premium B', description: 'Another premium test prize', imageUrl: '', entries: [], totalTicketsInPrize: 0, tierId: premiumTierId, numberOfWinners: 2 },
+      { name: 'Test Prize 4 - Standard A', description: 'A standard test prize', imageUrl: '', entries: [], totalTicketsInPrize: 0, tierId: standardTierId, numberOfWinners: 1 },
+      { name: 'Test Prize 5 - Standard B', description: 'Another standard test prize', imageUrl: '', entries: [], totalTicketsInPrize: 0, tierId: standardTierId, numberOfWinners: 1 },
+    ];
+    for (const prize of prizesToCreate) {
+      await addPrize(prize);
+      result.prizesCreated++;
+    }
+  }
+
+  return result;
+};
+
+export const bulkAllocateTicketsForTest = async (): Promise<{ allocationsCreated: number }> => {
+  // Fetch current users and prizes from Firebase
+  const users = await getUsers();
+  const prizes = await getPrizes();
+
+  const nonAdminUsers = users.filter(u => !ADMIN_IDS.includes(u.employeeId));
+  if (nonAdminUsers.length === 0 || prizes.length === 0) {
+    return { allocationsCreated: 0 };
+  }
+
+  // Build a map of prize entries: prizeId -> { userId -> numTickets }
+  const prizeEntriesMap: Record<string, Record<string, number>> = {};
+  prizes.forEach(p => {
+    prizeEntriesMap[p.id!] = {};
+    (p.entries || []).forEach(e => {
+      prizeEntriesMap[p.id!][e.userId] = e.numTickets;
+    });
+  });
+
+  let allocationsCreated = 0;
+
+  for (const user of nonAdminUsers) {
+    const totalTickets = user.tickets || 10;
+    let remainingTickets = totalTickets;
+    const userId = user.employeeId;
+    const userName = `${user.firstName} ${user.lastName}`;
+
+    // Pick 1-4 random prizes
+    const maxPrizes = Math.min(prizes.length, Math.ceil(Math.random() * 3) + 1);
+    const shuffled = [...prizes].sort(() => Math.random() - 0.5);
+    const selectedPrizes = shuffled.slice(0, maxPrizes);
+
+    for (let i = 0; i < selectedPrizes.length; i++) {
+      if (remainingTickets <= 0) break;
+      const prize = selectedPrizes[i];
+      const prizeId = prize.id!;
+
+      let ticketsForPrize: number;
+      if (i === selectedPrizes.length - 1) {
+        ticketsForPrize = remainingTickets;
+      } else {
+        const maxForThis = Math.floor(remainingTickets * 0.5);
+        ticketsForPrize = Math.max(1, Math.floor(Math.random() * maxForThis) + 1);
+      }
+
+      // Update in-memory map
+      prizeEntriesMap[prizeId][userId] = (prizeEntriesMap[prizeId][userId] || 0) + ticketsForPrize;
+      remainingTickets -= ticketsForPrize;
+
+      // Write allocation to Firebase
+      await allocateTickets({
+        lotteryId: 'default',
+        prizeId,
+        userId,
+        userName,
+        tickets: prizeEntriesMap[prizeId][userId],
+        timestamp: new Date().toISOString(),
+      });
+      allocationsCreated++;
+    }
+  }
+
+  // Batch update all prize entries
+  for (const prize of prizes) {
+    const entriesMap = prizeEntriesMap[prize.id!];
+    const entries = Object.entries(entriesMap)
+      .filter(([, numTickets]) => numTickets > 0)
+      .map(([userId, numTickets]) => ({ userId, numTickets }));
+    await updatePrizeEntries(prize.id!, entries);
+  }
+
+  return { allocationsCreated };
+};
+
+export const clearTestData = async (): Promise<void> => {
+  const batch = writeBatch(db);
+
+  // 1. Find and delete test users
+  const usersSnap = await getDocs(collection(db, 'users'));
+  const testUserDocIds: string[] = [];
+  const testEmployeeIds: string[] = [];
+  usersSnap.forEach(d => {
+    const data = d.data();
+    if (data.employeeId && data.employeeId.startsWith(TEST_USER_PREFIX)) {
+      batch.delete(d.ref);
+      testUserDocIds.push(d.id);
+      testEmployeeIds.push(data.employeeId);
+    }
+  });
+
+  // 2. Find and delete test prizes
+  const prizesSnap = await getDocs(collection(db, 'prizes'));
+  const testPrizeIds: string[] = [];
+  prizesSnap.forEach(d => {
+    const data = d.data();
+    if (data.name && data.name.startsWith(TEST_PRIZE_PREFIX)) {
+      batch.delete(d.ref);
+      testPrizeIds.push(d.id);
+    }
+  });
+
+  // 3. Delete allocations for test users
+  const allocsSnap = await getDocs(collection(db, 'allocations'));
+  allocsSnap.forEach(d => {
+    const data = d.data();
+    if (testEmployeeIds.includes(data.userId) || testPrizeIds.includes(data.prizeId)) {
+      batch.delete(d.ref);
+    }
+  });
+
+  // 4. Delete winners for test prizes/users
+  const winnersSnap = await getDocs(collection(db, 'winners'));
+  winnersSnap.forEach(d => {
+    const data = d.data();
+    if (testPrizeIds.includes(data.prizeId) || testEmployeeIds.includes(data.winnerId)) {
+      batch.delete(d.ref);
+    }
+  });
+
+  // 5. Remove test user entries from non-test prizes
+  prizesSnap.forEach(d => {
+    const data = d.data();
+    if (!data.name?.startsWith(TEST_PRIZE_PREFIX)) {
+      const entries = (data.entries || []).filter(
+        (e: { userId: string }) => !testEmployeeIds.includes(e.userId)
+      );
+      if (entries.length !== (data.entries || []).length) {
+        const totalTicketsInPrize = entries.reduce((sum: number, e: { numTickets: number }) => sum + e.numTickets, 0);
+        batch.update(d.ref, { entries, totalTicketsInPrize });
+      }
+    }
+  });
+
+  await batch.commit();
+};


### PR DESCRIPTION
Adds three Firebase service functions (seedTestData, bulkAllocateTicketsForTest,
clearTestData) that bypass the reducer to write directly to Firebase, fixing
the bug where random allocation validated against the admin's ticket pool.

Replaces the Testing Helper UI in WinnerDrawing with buttons for seeding
test data, allocating tickets, full setup, and cleanup with confirmation.

https://claude.ai/code/session_015mgH2SvGgABDjoAXx2Ttow